### PR TITLE
various changes to data exploration, data preparation, model development, and model evaluation/selection sections

### DIFF
--- a/src/homework1-data621.Rmd
+++ b/src/homework1-data621.Rmd
@@ -106,7 +106,18 @@ ggplot(train, aes(x=TARGET_WINS)) +
   labs(title = "Distribution of Wins (Boxplot)", x = "Number of Wins", y = "Count")
 ```
 
-Let's take a look at the summary statistics for all the variables:
+We could describe the average team's season using the mean for all variables below:
+
+```{r summary-stats0, echo=F}
+cMeans <- as.data.frame(round(colMeans(train, na.rm = TRUE), 1))
+colnames(cMeans) <- NULL
+kable(cMeans, format = "simple")
+
+```
+
+## Data Preparation:
+
+Let's take a closer look at all the summary statistics for these variables and identify any data completeness issues:
 
 ```{r summary-stats, echo=F}
 summary(train)
@@ -155,6 +166,8 @@ cor(train_imputed, df$TARGET_WINS)
 
 None of the independent variables seem to have such high correlation with `TARGET_WINS`. `TEAM_BATTING_H` is most highly correlated, with a correlation of 0.39. `TEAM_BATTING_H`, `TEAM_BATTING_2B`, `TEAM_BATTING_3B`, `TEAM_BATTING_HR`, `TEAM_BATTING_BB`, `TEAM_BASERUN_SB`, `TEAM_BASERUN_CS`, `TEAM_PITCHING_HR`, and `TEAM_PITCHING_BB` are all positively correlated with `TARGET_WINS` while `TEAM_BATTING_SO`, `TEAM_PITCHING_H`, `TEAM_PITCHING_SO`, `TEAM_FIELDING_E`, and `TEAM_FIELDING_DP` are negatively correlated. 
 
+Some of these correlations are surprising, as we would have expected `TEAM_BASERUN_CS`, `TEAM_PITCHING_HR`, and `TEAM_PITCHING_BB` to be negatively correlated with `TARGET_WINS`, and we would have expected `TEAM_PITCHING_SO` and `TEAM_FIELDING_DP` to be positively correlated with `TARGET_WINS`. We won't exclude them from our models based solely on this surprise, however. 
+
 Let's review relationships between batting independent variables. 
 
 ```{r batting_rel, fig.show='hold', fig.align='center', out.width='60%'}
@@ -174,9 +187,9 @@ kdepairs(subset_pitching)
 
 There isn't very strong correlation between the other independent variables similar to the batting statistics although there are more examples of skewed data with these inputs. Once again, we can see that we will need to transform some of these variables. 
 
-## Modeling
+## Model Development:
 
-First, let's create a basic model with the untransformed variables:
+First, let's create a basic model with all untransformed variables:
 
 ```{r scatter-plots, echo=FALSE, message=FALSE}
 lm_all <- lm(TARGET_WINS~., train_imputed)
@@ -234,7 +247,7 @@ par(mai=c(.3,.3,.3,.3))
 plot(lm_all_reduced_hits)
 ```
 
-The Q-Q plot shows that the residuals of this model are fairly normally distributed. The residuals vs. fitted plot shows a cluster of residuals and a seeming outlying point. There is no general pattern seen here and the cluster of points seems to indicate that homoscedasticity is satisfied for this model.
+The Q-Q plot shows that the residuals of this model are fairly normally distributed. The residuals vs. fitted plot shows a cluster of residuals and a seeming outlying point. There is no general pattern seen here and the cluster of points seems to indicate that homoscedasticity is satisfied for this model. 
 
 Let's try transforming some of our variables to come up with a more accurate model. 
 
@@ -243,7 +256,7 @@ Let's try transforming some of our variables to come up with a more accurate mod
 ```{r transformation_model1, echo = FALSE}
 train_imputed_transformed <- train_imputed
 #Add a small constant to TEAM_PITCHING_SO so there are no 0 values.
-train_imputed_transformed$TEAM_PITCHING_SO <- train_imputed_transformed$TEAM_PITCHING_SO + 1
+train_imputed_transformed$TEAM_PITCHING_SO <- train_imputed_transformed$TEAM_PITCHING_SO + 0.001
 par(mfrow=c(2,2))
 par(mai=c(.3,.3,.3,.3))
 #Compare how easy to understand transformations alter the distribution
@@ -277,7 +290,7 @@ for (i in 1:(length(variables))){
     #Add a small constant to columns with any 0 values
     if (sum(train_imputed_transformed[[variables[i]]] == 0) > 0){
         train_imputed_transformed[[variables[i]]] <-
-            train_imputed_transformed[[variables[i]]] + 1
+            train_imputed_transformed[[variables[i]]] + 0.001
     }
 }
 for (i in 1:(length(variables))){
@@ -291,6 +304,8 @@ for (i in 1:(length(variables))){
     lambdas <- append(lambdas, lambda)
 }
 lambdas <- as.data.frame(cbind(variables, lambdas))
+adj <- c("log", "fourth root", "square root", "log", "square", "square inverse", "cube root", "inverse")
+lambdas <- cbind(lambdas, adj)
 kable(lambdas, format = "simple")
 par(mfrow=c(3, 3))
 par(mai=c(.3,.3,.3,.3))
@@ -314,14 +329,10 @@ hist(train_imputed_transformed$TEAM_FIELDING_E^-1,
 
 ```
 
-Adjusting the ideal lambdas proposed for several variables to commonly understand transformations, we see mixed results on normalizing the distributions. Let's use the same variables from our final untransformed model above to see if we can improve the model using transformations.
+Adjusting the ideal lambdas proposed for several variables to commonly understood transformations, we see mixed results on normalizing the distributions. Let's use the same variables from our final untransformed model above to see if we can improve the model using transformations.
 
 ```{r}
-adj <- c(NA, 0.25, 0.5, NA, 2, -2, 0.33, -1)
-lambdas <- cbind(lambdas, adj)
-# check for log transform
-any(train_imputed$TEAM_BASERUN_SB <= 0)
-lm_trans <- lm(TARGET_WINS ~ TEAM_BATTING_H + I(TEAM_BATTING_BB**2) + log(TEAM_BASERUN_SB + .0001) + I(TEAM_PITCHING_SO**.5) + I(TEAM_FIELDING_E**-1) + TEAM_FIELDING_DP, train_imputed)
+lm_trans <- lm(TARGET_WINS ~ TEAM_BATTING_H + TEAM_BATTING_BB + I(TEAM_BATTING_BB**2) + log(TEAM_BASERUN_SB + .0001) + I(TEAM_PITCHING_SO**.5) + I(TEAM_FIELDING_E**-1) + TEAM_FIELDING_DP, train_imputed)
 summary(lm_trans)
 ```
 
@@ -342,7 +353,7 @@ par(mai=c(.3,.3,.3,.3))
 plot(lm_trans_reduced)
 ```
 
-Once again, the Q-Q plot shows that the residuals are fairly normally distributed. From the plot of Cook's distance, it seems there are less possible leverage points. The residuals vs. fitted plot also seems to indicate that homoscedasticity is satisfied. 
+Once again, the Q-Q plot shows that the residuals are fairly normally distributed. From the plot of Cook's distance, it seems there are fewer possible leverage points. The residuals vs. fitted plot also seems to indicate that homoscedasticity is satisfied. 
 
 Now we can make a model with inputs that we know from baseball.
 
@@ -378,13 +389,16 @@ plot(lm_select$residuals)
 Let's plot our response variable (*Total Wins*) versus each of our predictor variables to get a sense of linear relationships.
 
 ```{r plot-select-vars, echo=FALSE, message=FALSE}
-# Plot our response variable for each predictor variable to get a sense of
+par(mfrow=c(2,2))
+par(mai=c(.3,.3,.3,.3))
 plot(TARGET_WINS ~ TEAM_BATTING_H + TEAM_BATTING_BB + TEAM_PITCHING_H + TEAM_PITCHING_BB, data=train)
 ```
 
-## Model Evaluation/Selection 
+**Discussion Missing**
 
-We'll need to read in our [evaluation data](https://github.com/andrewbowen19/businessAnalyticsDataMiningDATA621/blob/main/data/moneyball-evaluation-data.csv), which is hosted on GitHub for reproduceability. 
+## Model Evaluation/Selection:
+
+First we read in our [evaluation data](https://github.com/andrewbowen19/businessAnalyticsDataMiningDATA621/blob/main/data/moneyball-evaluation-data.csv).
 
 ```{r echo=FALSE}
 eval_data_url <- "https://raw.githubusercontent.com/andrewbowen19/businessAnalyticsDataMiningDATA621/main/data/moneyball-evaluation-data.csv"
@@ -392,7 +406,7 @@ eval_data_url <- "https://raw.githubusercontent.com/andrewbowen19/businessAnalyt
 eval <- read.csv(eval_data_url)
 ```
 
-Let's make some predictions on our evaluation data from the models we've made
+Now we can make some predictions on the test holdout data and compare results from our models before we select the best model to use on the evaluation data. 
 
 ```{r}
 test <- drop_na(test)
@@ -403,17 +417,12 @@ predict_reduced <- predict(lm_all_reduced, test)
 predict_transformed_reduced <- predict(lm_trans_reduced, test)
 ```
 
+We can use Root-mean Squared Error (RMSE) to analyze our models from above. This is one way to measure the performance of a model. In simple terms, a smaller RMSE value indicates better model performance when predicting on new data.
 
-Writing a quick RMSE function
 ```{r}
 rmse <- function(c1, c2){
     sqrt(mean((c1 - c2)^2))
-    }
-```
-
-We can use the [Root-mean Squared Error](https://statisticsbyjim.com/regression/root-mean-square-error-rmse/) (RMSE) (from the `modelr` package) to analyze our models from above. This is one way to measure the performance of a model. In simple terms, a smaller RMSE value indicates better model performance when predicting on new data.
-
-```{r}
+}
 #Calculate RMSE and print to screen
 rmse_all <- rmse(predict_all, test$TARGET_WINS)
 rmse_reduced <- rmse(predict_reduced, test$TARGET_WINS)
@@ -424,20 +433,22 @@ print(rmse_reduced)
 print(rmse_transformed_reduced)
 ```
 
-
-Lastly, we can predict on our `eval` data based on the best RMSE value coming from our *reduced* model. Since we don't have `TARGET_WINS` in our evaluation data, we won't be able to evaluate the model performance against actual win totals. 
+The model with the lowest RMSE is our all variable model without transformations, so we will make predictions on the evaluation data using this model. Since we don't have `TARGET_WINS` in our evaluation data, we won't be able to evaluate the model performance against actual win totals. 
 
 However, we can look at the distribution of predicted wins to make sure our model predicts reasonable values. Knowing what we know about baseball, average teams tend to win $~80$ games in a season (out of 162 total regular season games). 
 
 ```{r}
 # Predict and plot on evaluation data (no wins listed)
-predict_reduced_eval <- as.data.frame(predict(lm_all_reduced, eval))
+predict_all_eval <- as.data.frame(predict(lm_all, eval))
 
-
-ggplot(as.data.frame(predict_reduced_eval), aes(x = predict(lm_all_reduced, eval))) + geom_histogram(bins=15) + labs(x="Wins", title="Predicted Wins (Reduced Model): Evaluation Data.")
+ggplot(as.data.frame(predict_all_eval), aes(x = predict(lm_all, eval))) + geom_histogram(bins=15) + labs(x="Wins", title="Predicted Wins (All Variables Untransformed Model): Evaluation Data.")
 ```
 
 Roughly speaking, these predicted win totals look roughly normal and centered around 80 wins, which is expected.
+
+## Conclusions:
+
+**Discussion Missing**
 
 # Appendix: Report Code
 


### PR DESCRIPTION
added a colmeans table for all variables to give a snapshot of the average team's season before looking into missing values;
added discussion of which variables we expected to have neg vs. pos correlations and vice versa; added data preparation section header;
fixed lambdas table to include adjusted transformations; updated transformed model to include both TEAM_BATTING_BB^2 and its lower order term TEAM_BATTING_BB since lower order terms are always required in models even if they're not significant on their own; changed Modeling header to Model Development;
paired the last diagnostic plots shown before Model Evaluation/Selection section together; added a **Discussion Missing** note for the last diagnostic plots shown before Model Evaluation/Selection section; clarified the text in Model Evaluation/Selection section; selected all model for evaluation based on rmse, as reduced model had higher rmse; added a Conclusions section header and a **Discussion Missing** note below